### PR TITLE
Making model fields optional

### DIFF
--- a/Sources/Model/Clouds.swift
+++ b/Sources/Model/Clouds.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 public struct Clouds: Codable {
-    public let all: Int
+    public let all: Int?
 }

--- a/Sources/Model/Main.swift
+++ b/Sources/Model/Main.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public struct Main: Codable {
-    public let temp: Double
-    public let pressure: Double
-    public let humidity: Int
-    public let tempMin: Double
-    public let tempMax: Double
+    public let temp: Double?
+    public let pressure: Double?
+    public let humidity: Int?
+    public let tempMin: Double?
+    public let tempMax: Double?
 
     enum CodingKeys: String, CodingKey {
         case temp

--- a/Sources/Model/Sys.swift
+++ b/Sources/Model/Sys.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public struct Sys: Codable {
     public let id: Int
-    public let type: Int
-    public let message: Double
-    public let country: String
-    public let sunrise: Int
-    public let sunset: Int
+    public let type: Int?
+    public let message: Double?
+    public let country: String?
+    public let sunrise: Int?
+    public let sunset: Int?
 }

--- a/Sources/Model/Weather.swift
+++ b/Sources/Model/Weather.swift
@@ -10,14 +10,14 @@ import Foundation
 
 public struct Weather: Codable {
     public let id: Int
-    public let visibility: Int
-    public let name: String
-    public let coord: Coord
-    public let wind: Wind
-    public let base: String
-    public let dt: Int
-    public let weather: [WeatherData]
-    public let sys: Sys
-    public let clouds: Clouds
-    public let main: Main
+    public let visibility: Int?
+    public let name: String?
+    public let coord: Coord?
+    public let wind: Wind?
+    public let base: String?
+    public let dt: Int?
+    public let weather: [WeatherData]?
+    public let sys: Sys?
+    public let clouds: Clouds?
+    public let main: Main?
 }

--- a/Sources/Model/WeatherData.swift
+++ b/Sources/Model/WeatherData.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct WeatherData: Codable {
     public let id: Int
-    public let main: String
-    public let description: String
-    public let icon: String
+    public let main: String?
+    public let description: String?
+    public let icon: String?
 }

--- a/Sources/Model/Wind.swift
+++ b/Sources/Model/Wind.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct Wind: Codable {
-    public let speed: Double
+    public let speed: Double?
     public let deg: Double?
 
     public var degString: String {

--- a/Tests/OpenWeatherKitTests/Model/WeatherTests.swift
+++ b/Tests/OpenWeatherKitTests/Model/WeatherTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class WeatherTests: XCTestCase {
     func testDecode() {
-        let path = Bundle(for: type(of: self)).path(forResource: "weather", ofType: "json")
+              let path = Bundle(for: type(of: self)).path(forResource: "weather", ofType: "json")
         let data = try! String(contentsOfFile: path!).data(using: .utf8)!
         let decoder = JSONDecoder()
 
@@ -25,28 +25,28 @@ class WeatherTests: XCTestCase {
         XCTAssertEqual(1508842800, weather.dt)
 
         //Clouds
-        XCTAssertEqual(90, weather.clouds.all)
+        XCTAssertEqual(90, weather.clouds?.all)
         //sys
-        XCTAssertEqual(1, weather.sys.type)
-        XCTAssertEqual(5625, weather.sys.id)
-        XCTAssertEqual(0.0044, weather.sys.message)
-        XCTAssertEqual("FR", weather.sys.country)
-        XCTAssertEqual(1508826388, weather.sys.sunrise)
-        XCTAssertEqual(1508863034, weather.sys.sunset)
+        XCTAssertEqual(1, weather.sys?.type)
+        XCTAssertEqual(5625, weather.sys?.id)
+        XCTAssertEqual(0.0044, weather.sys?.message)
+        XCTAssertEqual("FR", weather.sys?.country)
+        XCTAssertEqual(1508826388, weather.sys?.sunrise)
+        XCTAssertEqual(1508863034, weather.sys?.sunset)
         //Coord
-        XCTAssertEqual(50.49, weather.coord.lat)
-        XCTAssertEqual(2.96, weather.coord.lon)
+        XCTAssertEqual(50.49, weather.coord?.lat)
+        XCTAssertEqual(2.96, weather.coord?.lon)
         //Wind
-        XCTAssertEqual(5.7, weather.wind.speed)
-        XCTAssertEqual(220, weather.wind.deg)
+        XCTAssertEqual(5.7, weather.wind?.speed)
+        XCTAssertEqual(220, weather.wind?.deg)
         //Main
-        XCTAssertEqual(289.61, weather.main.temp)
-        XCTAssertEqual(1021, weather.main.pressure)
-        XCTAssertEqual(88, weather.main.humidity)
-        XCTAssertEqual(288.15, weather.main.tempMin)
-        XCTAssertEqual(290.15, weather.main.tempMax)
+        XCTAssertEqual(289.61, weather.main?.temp)
+        XCTAssertEqual(1021, weather.main?.pressure)
+        XCTAssertEqual(88, weather.main?.humidity)
+        XCTAssertEqual(288.15, weather.main?.tempMin)
+        XCTAssertEqual(290.15, weather.main?.tempMax)
         //Weather
-        let weatherData = weather.weather.first!
+        let weatherData = weather.weather!.first!
         XCTAssertEqual(804, weatherData.id)
         XCTAssertEqual("Clouds", weatherData.main)
         XCTAssertEqual("overcast clouds", weatherData.description)

--- a/Tests/OpenWeatherKitTests/Model/WeatherTests.swift
+++ b/Tests/OpenWeatherKitTests/Model/WeatherTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class WeatherTests: XCTestCase {
     func testDecode() {
-              let path = Bundle(for: type(of: self)).path(forResource: "weather", ofType: "json")
+        let path = Bundle(for: type(of: self)).path(forResource: "weather", ofType: "json")
         let data = try! String(contentsOfFile: path!).data(using: .utf8)!
         let decoder = JSONDecoder()
 

--- a/Tests/OpenWeatherKitTests/WeatherApiTests.swift
+++ b/Tests/OpenWeatherKitTests/WeatherApiTests.swift
@@ -74,7 +74,10 @@ class WeatherApiTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(mockSession.lastURL?.absoluteString, "https://api.openweathermap.org/data/2.5/weather?APPID=keytest&lat=5.567788&lon=1.5544")
+        // Additional params are not guaranteed in order as they are passed in a dict
+        XCTAssert(
+            mockSession.lastURL?.absoluteString == "https://api.openweathermap.org/data/2.5/weather?APPID=keytest&lat=5.567788&lon=1.5544" ||
+            mockSession.lastURL?.absoluteString == "https://api.openweathermap.org/data/2.5/weather?APPID=keytest&lon=1.5544&lat=5.567788")
         XCTAssertTrue(dataTask.resumeCall)
         waitForExpectations(timeout: 5, handler: nil)
     }
@@ -131,7 +134,10 @@ class WeatherApiTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(mockSession.lastURL?.absoluteString, "https://api.openweathermap.org/data/2.5/weather?APPID=keytest&lat=5.567788&lon=1.5544")
+        // Additional params are not guaranteed in order as they are passed in a dict
+        XCTAssert(
+            mockSession.lastURL?.absoluteString == "https://api.openweathermap.org/data/2.5/weather?APPID=keytest&lat=5.567788&lon=1.5544" ||
+                mockSession.lastURL?.absoluteString == "https://api.openweathermap.org/data/2.5/weather?APPID=keytest&lon=1.5544&lat=5.567788")
         XCTAssertTrue(dataTask.resumeCall)
         waitForExpectations(timeout: 5, handler: nil)
     }
@@ -187,7 +193,10 @@ class WeatherApiTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(mockSession.lastURL?.absoluteString, "https://api.openweathermap.org/data/2.5/forecast?APPID=keytest&lat=5.567788&lon=1.5544")
+        // Additional params are not guaranteed in order as they are passed in a dict
+        XCTAssert(
+            mockSession.lastURL?.absoluteString == "https://api.openweathermap.org/data/2.5/forecast?APPID=keytest&lat=5.567788&lon=1.5544" ||
+                mockSession.lastURL?.absoluteString == "https://api.openweathermap.org/data/2.5/forecast?APPID=keytest&lon=1.5544&lat=5.567788")
         XCTAssertTrue(dataTask.resumeCall)
         waitForExpectations(timeout: 5, handler: nil)
     }
@@ -215,7 +224,10 @@ class WeatherApiTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(mockSession.lastURL?.absoluteString, "https://api.openweathermap.org/data/2.5/forecast?APPID=keytest&lat=5.567788&lon=1.5544")
+        // Additional params are not guaranteed in order as they are passed in a dict
+        XCTAssert(
+            mockSession.lastURL?.absoluteString == "https://api.openweathermap.org/data/2.5/forecast?APPID=keytest&lat=5.567788&lon=1.5544" ||
+                mockSession.lastURL?.absoluteString == "https://api.openweathermap.org/data/2.5/forecast?APPID=keytest&lon=1.5544&lat=5.567788")
         XCTAssertTrue(dataTask.resumeCall)
         waitForExpectations(timeout: 5, handler: nil)
     }
@@ -244,7 +256,10 @@ class WeatherApiTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(mockSession.lastURL?.absoluteString, "https://api.openweathermap.org/data/2.5/forecast?APPID=keytest&lat=5.567788&lon=1.5544")
+        // Additional params are not guaranteed in order as they are passed in a dict
+        XCTAssert(
+            mockSession.lastURL?.absoluteString == "https://api.openweathermap.org/data/2.5/forecast?APPID=keytest&lat=5.567788&lon=1.5544" ||
+                mockSession.lastURL?.absoluteString == "https://api.openweathermap.org/data/2.5/forecast?APPID=keytest&lon=1.5544&lat=5.567788")
         XCTAssertTrue(dataTask.resumeCall)
         waitForExpectations(timeout: 5, handler: nil)
     }


### PR DESCRIPTION
In practice, many locations don't have all the fields, and with the current required fields if a location is missing 1 field e.g. `visibility` then the whole decoding fails.

This PR marks most of the fields optional so that missing fields are tolerated.