### PR TITLE
Make Sys.id & WeatherData.id also optional

### DIFF
--- a/Sources/Model/Sys.swift
+++ b/Sources/Model/Sys.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct Sys: Codable {
-    public let id: Int
+    public let id: Int?
     public let type: Int?
     public let message: Double?
     public let country: String?

--- a/Sources/Model/WeatherData.swift
+++ b/Sources/Model/WeatherData.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct WeatherData: Codable {
-    public let id: Int
+    public let id: Int?
     public let main: String?
     public let description: String?
     public let icon: String?


### PR DESCRIPTION
Thought whenever a Sys is provided it should at least have an `id`, but just received some weather data which failed to parse because the Sys part didn't have `id`... So making it optional as well as WeatherData just in case.

The data received:
```
{
  "coord": {
    "lon": 0,
    "lat": 37.33
  },
  "weather": [
    {
      "id": 803,
      "main": "Clouds",
      "description": "broken clouds",
      "icon": "04d"
    }
  ],
  "base": "stations",
  "main": {
    "temp": 292.765,
    "pressure": 1013.8,
    "humidity": 76,
    "temp_min": 292.765,
    "temp_max": 292.765,
    "sea_level": 1013.8,
    "grnd_level": 1014.04
  },
  "wind": {
    "speed": 9.4,
    "deg": 41.423
  },
  "clouds": {
    "all": 81
  },
  "dt": 1560328094,
  "sys": {
    "message": 0.005,
    "country": "ES",
    "sunrise": 1560314339,
    "sunset": 1560367245
  },
  "timezone": 0,
  "id": 2516169,
  "name": "La Barra",
  "cod": 200
}
```